### PR TITLE
[aulë][claude] Vérifier que le viewer HTML fonctionne sans serveur local (standalone)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "aule": {
+      "command": "python3",
+      "args": [
+        "/app/src/mcp_bridge.py"
+      ],
+      "env": {
+        "AULE_API_URL": "http://localhost:9000",
+        "AULE_WORKER_PROJECT": "533y\u00e8s"
+      }
+    }
+  }
+}

--- a/viewer/README_STANDALONE.md
+++ b/viewer/README_STANDALONE.md
@@ -1,0 +1,53 @@
+# Viewer HTR Standalone
+
+## Utilisation
+
+Le viewer HTR peut être utilisé de deux manières :
+
+### 1. Avec un serveur local (recommandé)
+
+Cette méthode permet de charger dynamiquement toutes les données :
+
+```bash
+# Depuis le dossier viewer/
+python simple_server.py
+# Ou avec Python 3
+python3 -m http.server 8000
+```
+
+Puis ouvrir http://localhost:8000/htr_viewer_standalone.html
+
+### 2. Sans serveur (standalone)
+
+**⚠️ Limitations importantes :**
+- Les navigateurs modernes appliquent une politique CORS qui empêche le chargement de fichiers locaux via JavaScript
+- L'affichage des images fonctionne, mais le chargement des transcriptions et résultats JSON peut être bloqué
+- Pour contourner cette limitation sur Chrome : lancer avec `--allow-file-access-from-files`
+- Sur Firefox : taper `about:config` et mettre `security.fileuri.strict_origin_policy` à false (non recommandé)
+
+Pour ouvrir directement le fichier :
+1. Ouvrir `viewer/htr_viewer_standalone.html` dans votre navigateur
+2. Les images devraient s'afficher correctement
+3. Les transcriptions peuvent ne pas se charger à cause des restrictions CORS
+
+## Structure des fichiers
+
+Le viewer attend la structure suivante :
+```
+projet/
+├── viewer/
+│   └── htr_viewer_standalone.html
+├── images/                          # Images sources (PNG)
+├── transcriptions_de_référence/     # Transcriptions de référence (MD)
+├── résultats/                       # Résultats des modèles (JSON)
+└── data/
+    ├── images_list.json             # Liste des images
+    └── models_list.json             # Liste des modèles
+```
+
+## Solution alternative
+
+Pour un déploiement web sans serveur, envisager :
+1. Héberger sur GitHub Pages
+2. Utiliser un CDN pour les fichiers de données
+3. Intégrer toutes les données directement dans le HTML (version lourde mais 100% standalone)

--- a/viewer/htr_viewer_standalone.html
+++ b/viewer/htr_viewer_standalone.html
@@ -67,6 +67,13 @@
     <div class="container-fluid">
         <h1 class="mb-4">533yes - Viewer de transcriptions HTR (Standalone)</h1>
         
+        <!-- Avertissement CORS -->
+        <div id="corsWarning" class="alert alert-warning alert-dismissible fade show" role="alert" style="display: none;">
+            <strong>Limitation CORS détectée !</strong> Le chargement des fichiers locaux est bloqué par votre navigateur.
+            <br>Pour une expérience complète, utilisez un serveur local : <code>python -m http.server 8000</code>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        
         <div class="row mb-3">
             <div class="col-md-6">
                 <label for="imageSelector" class="form-label">Sélectionner une image :</label>
@@ -135,16 +142,21 @@
             console.log(`[${timestamp}] ${message}`);
         }
         
-        // Configuration - À remplacer par des données réelles
+        // Configuration avec chemins relatifs corrects depuis le dossier viewer/
         const config = {
-            // Utiliser des chemins relatifs pour la compatibilité avec GitHub Pages
-            imagesPath: './images/',
-            referencePath: './transcriptions_de_référence/',
-            resultsPath: './résultats/'
+            // Chemins relatifs vers les dossiers à la racine du projet
+            imagesPath: '../images/',
+            referencePath: '../transcriptions_de_référence/',
+            resultsPath: '../résultats/'
         };
 
-        // Données intégrées directement dans le HTML (au lieu de les charger via fetch)
-        const IMAGES_LIST = [
+        // Variables globales pour stocker les données
+        let IMAGES_LIST = [];
+        let MODELS_LIST = [];
+        let corsError = false;
+        
+        // Données de fallback intégrées (utilisées si le chargement externe échoue)
+        const FALLBACK_IMAGES_LIST = [
             'AN-284AP-4-doss 14_page_27.png',
             'AN-284AP-4-doss 11_page_39.png',
             'AN-284AP-4-doss 11_page_36.png',
@@ -162,7 +174,7 @@
             'AN-284AP-18-fasc ms extr Moniteur carriere Sieyes-1789-1799_page_4.png'
         ];
 
-        const MODELS_LIST = [
+        const FALLBACK_MODELS_LIST = [
             { id: 'amazon_nova-lite-v1', name: 'Amazon Nova Lite', type: 'propriétaire' },
             { id: 'McCATMuS_nfd_nofix_V1', name: 'McCATMuS', type: 'libre' },
             { id: 'ManuMcFondue', name: 'ManuMcFondue', type: 'libre' },
@@ -179,6 +191,57 @@
             { id: 'mistralai_pixtral-large-2411', name: 'Mistral Pixtral Large', type: 'libre' }
         ];
 
+        // Fonction pour charger les données externes
+        async function loadExternalData() {
+            log("Tentative de chargement des données externes...");
+            
+            try {
+                // Essayer de charger la liste des images
+                const imagesResponse = await fetch('../data/images_list.json');
+                if (imagesResponse.ok) {
+                    IMAGES_LIST = await imagesResponse.json();
+                    log(`Images chargées depuis le fichier externe: ${IMAGES_LIST.length} images`);
+                }
+            } catch (error) {
+                log(`Erreur CORS pour images_list.json: ${error.message}`);
+                corsError = true;
+            }
+            
+            try {
+                // Essayer de charger la liste des modèles
+                const modelsResponse = await fetch('../data/models_list.json');
+                if (modelsResponse.ok) {
+                    const modelsData = await modelsResponse.json();
+                    // Transformer le format si nécessaire
+                    MODELS_LIST = modelsData.map(model => ({
+                        id: model.id,
+                        name: model.name || model.id,
+                        type: model.type || 'libre'
+                    }));
+                    log(`Modèles chargés depuis le fichier externe: ${MODELS_LIST.length} modèles`);
+                }
+            } catch (error) {
+                log(`Erreur CORS pour models_list.json: ${error.message}`);
+                corsError = true;
+            }
+            
+            // Si le chargement externe a échoué, utiliser les données de fallback
+            if (IMAGES_LIST.length === 0) {
+                IMAGES_LIST = FALLBACK_IMAGES_LIST;
+                log("Utilisation des données d'images intégrées (fallback)");
+            }
+            
+            if (MODELS_LIST.length === 0) {
+                MODELS_LIST = FALLBACK_MODELS_LIST;
+                log("Utilisation des données de modèles intégrées (fallback)");
+            }
+            
+            // Afficher l'avertissement CORS si nécessaire
+            if (corsError) {
+                document.getElementById('corsWarning').style.display = 'block';
+            }
+        }
+        
         // Fonction pour initialiser le sélecteur d'images
         function initImageSelector() {
             log("Initialisation du sélecteur d'images...");
@@ -388,9 +451,13 @@
         }
 
         // Initialiser l'application
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
             log("Initialisation de l'application...");
             try {
+                // Charger les données externes en premier
+                await loadExternalData();
+                
+                // Puis initialiser les sélecteurs
                 initImageSelector();
                 initModelSelector();
                 log("Initialisation terminée");

--- a/viewer/test_standalone.html
+++ b/viewer/test_standalone.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Viewer Standalone</title>
+</head>
+<body>
+    <h1>Test du Viewer Standalone</h1>
+    <p>Ce fichier teste l'accès aux ressources locales sans serveur.</p>
+    
+    <h2>Tests d'accès aux fichiers :</h2>
+    
+    <h3>1. Test accès image :</h3>
+    <img src="../images/AN-284AP-4-doss 14_page_27.png" width="200" alt="Test image" onerror="this.alt='ERREUR: Image non accessible'">
+    
+    <h3>2. Test accès fichier de données :</h3>
+    <div id="test-data">Chargement...</div>
+    
+    <h3>3. Lien vers le viewer complet :</h3>
+    <a href="htr_viewer_standalone.html">Ouvrir le viewer HTR standalone</a>
+    
+    <script>
+        // Test de chargement des données JSON
+        fetch('../data/images_list.json')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('test-data').innerHTML = 
+                    `✓ Données chargées : ${data.length} images trouvées`;
+            })
+            .catch(error => {
+                document.getElementById('test-data').innerHTML = 
+                    `✗ ERREUR: Impossible de charger les données (CORS policy)`;
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Amélioration du viewer HTR standalone pour qu'il fonctionne correctement sans serveur local.

## Changements effectués

### 1. Correction des chemins relatifs
- Images : `../images/`
- Transcriptions de référence : `../transcriptions_de_référence/`
- Résultats : `../résultats/`

### 2. Chargement dynamique avec fallback
- Tentative de chargement des données depuis les fichiers JSON externes (`../data/`)
- Données de fallback intégrées dans le HTML en cas d'échec (restrictions CORS)

### 3. Gestion des limitations CORS
- Avertissement affiché à l'utilisateur si les restrictions CORS sont détectées
- Instructions pour utiliser un serveur local si nécessaire

### 4. Documentation
- `viewer/README_STANDALONE.md` : Guide d'utilisation complet avec solutions aux limitations
- `viewer/test_standalone.html` : Page de test pour vérifier l'accès aux ressources

## Test
Pour tester le viewer standalone :
1. Ouvrir directement `viewer/htr_viewer_standalone.html` dans un navigateur
2. Les images devraient s'afficher correctement
3. Les transcriptions peuvent nécessiter un serveur local selon le navigateur

---
Automated by Aulë on 2026-02-28 | engine=claude