### PR TITLE
[aulë][claude] Supprimer le dossier backup_before_cleanup/ si plus nécessaire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ env/
 .vscode/
 *.swp
 *.swo 
-# Backup files
-backup_before_cleanup/
+
+# Claude MCP config (auto-added by Aule)
+.mcp.json


### PR DESCRIPTION
## Summary
- Le dossier `backup_before_cleanup/` n'existe pas dans le projet
- Suppression de la référence obsolète dans `.gitignore`
- La tâche est maintenant complétée

## Test plan
- [x] Vérification que le dossier n'existe pas : `find . -type d -name backup_before_cleanup` ne retourne rien
- [x] Vérification des références dans le code : seules restent dans ROADMAP.md (sera coché par le mainteneur)
- [x] Le fichier .gitignore ne contient plus la référence

Automated by Aulë on 2026-05-07 | engine=claude

🤖 Generated with [Claude Code](https://claude.ai/code)