### PR TITLE
[aulë][claude] Publier sur GitHub + release v1.0 (cf. next_steps.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+Toutes les modifications notables de ce projet seront documentées dans ce fichier.
+
+Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/),
+et ce projet adhère au [Versionnement Sémantique](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-07
+
+### Ajouté
+- Première version officielle du benchmark 533yès
+- Évaluation complète de 26 modèles HTR/OCR sur 15 manuscrits de Sieyès
+- Viewer HTML interactif pour l'exploration visuelle des résultats
+- Rapports détaillés d'analyse des performances par page et par modèle
+- Scripts Python reproductibles pour le benchmark
+- Transcriptions de référence (ground truth) des manuscrits
+- Documentation complète avec README et guides d'utilisation
+
+### Résultats clés
+- TrOCR (Base Handwritten) : meilleur modèle avec WER moyen de 8.7%
+- Kraken HTR United : deuxième position avec WER moyen de 14.5%
+- Florence-2 Large FT : troisième position avec WER moyen de 15.1%
+
+### Infrastructure
+- Configuration GitHub Pages pour le viewer interactif
+- Scripts de génération automatique des tableaux de performances
+- Serveur local simple pour les tests du viewer
+
+[1.0.0]: https://github.com/g-simiand/533yes/releases/tag/v1.0


### PR DESCRIPTION
## Résumé

Publication officielle du benchmark 533yès sur GitHub avec création de la release v1.0.

## Changements effectués

- ✅ **Création de la release GitHub v1.0** avec tag et notes détaillées
- 📝 **Ajout d'un fichier CHANGELOG.md** pour documenter les versions futures
- 🎉 **Publication officielle du benchmark** avec résultats complets

## Release créée

La release v1.0 a été créée avec succès : https://github.com/g-simiand/533yes/releases/tag/v1.0

### Contenu de la release

- Évaluation de 26 modèles HTR/OCR
- 15 manuscrits historiques de Sieyès analysés
- Viewer HTML interactif inclus
- Rapports détaillés des performances
- Scripts reproductibles

### Top 3 des modèles

1. TrOCR (Base Handwritten) - WER : 8.7%
2. Kraken HTR United - WER : 14.5%
3. Florence-2 Large FT - WER : 15.1%

## Test

La release est déjà publiée et accessible sur GitHub.

---

Automated by Aulë on 2026-05-07 | engine=claude