### PR TITLE
[aulë][claude] Ajouter `google/gemini-3-pro` au benchmark via OpenRouter

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ Ta tâche est de produire une transcription fidèle et précise, sans interprét
 # Define a list of known valid model IDs for OpenRouter
 VALID_OPENROUTER_MODELS = [
     "google/gemini-2.0-flash-001",
+    "google/gemini-3-pro",
     "qwen/qwen-vl-plus:free",
     "qwen/qwen2.5-vl-72b-instruct:free",
     "google/gemini-2.0-flash-thinking-exp:free",

--- a/models_to_test.json
+++ b/models_to_test.json
@@ -1,5 +1,6 @@
 [
     ["google/gemini-2.0-flash-001", "proprietary"],
+    ["google/gemini-3-pro", "proprietary"],
     ["qwen/qwen-vl-plus:free", "open"],
     ["qwen/qwen2.5-vl-72b-instruct:free", "open"],
     ["google/gemini-2.0-flash-thinking-exp:free", "proprietary"], 


### PR DESCRIPTION
## Summary
- Ajout du modèle `google/gemini-3-pro` dans la liste des modèles OpenRouter valides
- Configuration du modèle pour être testé dans le benchmark HTR
- Marqué comme modèle propriétaire

## Test plan
- [x] Validation de la syntaxe Python (config.py)
- [x] Validation du format JSON (models_to_test.json)
- [ ] Exécuter le benchmark avec le nouveau modèle

🤖 Generated with [Claude Code](https://claude.ai/code)