### PR TITLE
[aulë][claude] Ajouter `google/gemini-3-flash` au benchmark via OpenRouter

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ Ta tâche est de produire une transcription fidèle et précise, sans interprét
 # Define a list of known valid model IDs for OpenRouter
 VALID_OPENROUTER_MODELS = [
     "google/gemini-2.0-flash-001",
+    "google/gemini-3-flash",
     "qwen/qwen-vl-plus:free",
     "qwen/qwen2.5-vl-72b-instruct:free",
     "google/gemini-2.0-flash-thinking-exp:free",

--- a/models_to_test.json
+++ b/models_to_test.json
@@ -1,5 +1,6 @@
 [
     ["google/gemini-2.0-flash-001", "proprietary"],
+    ["google/gemini-3-flash", "proprietary"],
     ["qwen/qwen-vl-plus:free", "open"],
     ["qwen/qwen2.5-vl-72b-instruct:free", "open"],
     ["google/gemini-2.0-flash-thinking-exp:free", "proprietary"], 


### PR DESCRIPTION
## Summary
- Ajout du modèle `google/gemini-3-flash` dans la configuration du benchmark HTR
- Modèle propriétaire Google accessible via l'API OpenRouter
- Configuration cohérente avec l'ajout récent de `google/gemini-3-pro` (PR #27)

## Changements
- `config.py` : ajout dans la liste `VALID_OPENROUTER_MODELS`
- `models_to_test.json` : ajout avec le tag "proprietary"

## Test plan
- [x] Validation de la syntaxe Python (`py_compile`)
- [x] Validation du format JSON
- [ ] Test d'exécution du benchmark avec le nouveau modèle

Automated by Aulë on 2026-05-07 | engine=claude