### PR TITLE
[aulë][claude] Supprimer le dossier backup_before_cleanup/ si plus nécess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,6 @@ env/
 .vscode/
 *.swp
 *.swo 
-# Backup files
-backup_before_cleanup/
 
 # Claude MCP config (auto-added by Aule)
 .mcp.json


### PR DESCRIPTION
## Résumé
Le dossier `backup_before_cleanup/` n'existe plus dans le projet. Cette PR nettoie la référence obsolète dans le fichier `.gitignore`.

## Changements
- Suppression de l'entrée `backup_before_cleanup/` dans `.gitignore`
- Suppression du commentaire `# Backup files` associé

## Contexte
Le dossier `backup_before_cleanup/` était référencé dans `.gitignore` mais n'existe plus physiquement dans le projet. Cette entrée est donc devenue inutile.

---
Automated by Aulë on 2026-07-03 | engine=claude