### PR TITLE
[aulë][claude] Ajouter `google/gemini-3-pro` au benchmark via OpenRouter

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ VALID_OPENROUTER_MODELS = [
     "meta-llama/llama-3.2-11b-vision-instruct",
     "google/gemini-1.5-pro",
     "google/gemini-1.5-flash",
+    "google/gemini-3-pro",
     # Add more valid models as needed
 ]
 

--- a/models_to_test.json
+++ b/models_to_test.json
@@ -25,5 +25,6 @@
     ["anthropic/claude-3-opus", "proprietary"],
     ["meta-llama/llama-3.2-11b-vision-instruct", "open"],
     ["google/gemini-1.5-pro", "proprietary"],
-    ["google/gemini-1.5-flash", "proprietary"]
+    ["google/gemini-1.5-flash", "proprietary"],
+    ["google/gemini-3-pro", "proprietary"]
 ]


### PR DESCRIPTION
Automated by Aulë on 2026-07-03 | engine=claude

## Changements

Cette PR ajoute le modèle `google/gemini-3-pro` au benchmark HTR pour évaluer ses performances sur les manuscrits de Sieyès.

### Modifications apportées :
- ✅ Ajout de `google/gemini-3-pro` dans `models_to_test.json` (proprietary model)
- ✅ Ajout dans la liste `VALID_OPENROUTER_MODELS` de `config.py` pour la validation

### Tests effectués :
- ✅ Vérification de la syntaxe Python
- ✅ Validation du JSON
- ✅ Confirmation que le modèle est correctement référencé dans les deux fichiers

Le modèle est maintenant prêt à être testé dans le benchmark HTR via OpenRouter.